### PR TITLE
too many attacking cards fix

### DIFF
--- a/Durak/Models/Game.cs
+++ b/Durak/Models/Game.cs
@@ -147,8 +147,11 @@ namespace Durak.Models
                 
             }
 
+            if (playerId != gamePlayState.defenderId && playerHands[gamePlayState.defenderId].Count == gamePlayState.cardsInPlay.Count(kvp => kvp.Value == null) && allowPickUpPass)
+                return false;
+
             //  This method makes me want to hurl, but it's just temporary.
-            if (playerId != gamePlayState.defenderId )
+            if (playerId != gamePlayState.defenderId)
             {
                 var cardVal = friendlyPlayedName.Split("_")[0];
 


### PR DESCRIPTION
Added a check on card being played to make sure that if a player is actively defending they are not attacked with more card than what is in their hands.  If the defender picks up then there is still the opportunity for the attacker to play those cards at the end as per normal.